### PR TITLE
Add XuperOS sdk configs

### DIFF
--- a/conf/sdk.testnet.yaml
+++ b/conf/sdk.testnet.yaml
@@ -1,0 +1,7 @@
+# endorseService Info
+# testNet addrs
+endorseServiceHost: "14.215.179.74:37101"
+complianceCheck:
+  complianceCheckEndorseServiceFee: 10 
+  complianceCheckEndorseServiceFeeAddr: cHvBK1TTB52GYtVxHK7HnW8N9RTqkN99R
+  complianceCheckEndorseServiceAddr: XDxkpQkfLwG6h56e896f3vBHhuN5g6M9u

--- a/conf/sdk.yaml
+++ b/conf/sdk.yaml
@@ -1,5 +1,5 @@
 # endorseService Info
-# testNet addrs
+# XuperOS addrs
 endorseServiceHost: "39.156.69.83:37100"
 complianceCheck:
   complianceCheckEndorseServiceFee: 100

--- a/conf/sdk.yaml
+++ b/conf/sdk.yaml
@@ -1,7 +1,7 @@
 # endorseService Info
 # testNet addrs
-endorseServiceHost: "14.215.179.74:37101"
+endorseServiceHost: "39.156.69.83:37100"
 complianceCheck:
-  complianceCheckEndorseServiceFee: 10 
-  complianceCheckEndorseServiceFeeAddr: cHvBK1TTB52GYtVxHK7HnW8N9RTqkN99R
-  complianceCheckEndorseServiceAddr: XDxkpQkfLwG6h56e896f3vBHhuN5g6M9u
+  complianceCheckEndorseServiceFee: 100
+  complianceCheckEndorseServiceFeeAddr: aB2hpHnTBDxko3UoP2BpBZRujwhdcAFoT
+  complianceCheckEndorseServiceAddr: jknGxa6eyum1JrATWvSJKW3thJ9GKHA9n

--- a/config/config.go
+++ b/config/config.go
@@ -36,11 +36,11 @@ func GetInstance() *CommConfig {
 func GetConfig(configPath string, confName string) *CommConfig {
 	// default config
 	commConfig := &CommConfig{
-		EndorseServiceHost: "14.215.179.74:37101",
+		EndorseServiceHost: "39.156.69.83:37100",
 		ComplianceCheck: ComplianceCheckConfig{
-			ComplianceCheckEndorseServiceFee:     10,
-			ComplianceCheckEndorseServiceFeeAddr: "XBbhR82cB6PvaLJs3D4uB9f12bhmKkHeX",
-			ComplianceCheckEndorseServiceAddr:    "TYyA3y8wdFZyzExtcbRNVd7ZZ2XXcfjdw",
+			ComplianceCheckEndorseServiceFee:     100,
+			ComplianceCheckEndorseServiceFeeAddr: "aB2hpHnTBDxko3UoP2BpBZRujwhdcAFoT",
+			ComplianceCheckEndorseServiceAddr:    "jknGxa6eyum1JrATWvSJKW3thJ9GKHA9n",
 		},
 	}
 

--- a/example/sample.go
+++ b/example/sample.go
@@ -11,7 +11,7 @@ import (
 
 // define blockchain node and blockchain name
 var (
-	node   = "14.215.179.74:37101"
+	node   = "39.156.69.83:37100"
 	bcname = "xuper"
 )
 
@@ -28,6 +28,19 @@ func createAccount() (string, error) {
 	fmt.Println(acc.Mnemonic)
 
 	return acc.Mnemonic, nil
+}
+
+func usingAccount() (*account.Account, error) {
+	// load your account from the private key and secure code you download from xuper.baidu.com
+	// Note that put the downloaded private key file at path "./keys/private.key"
+	acc, err := account.GetAccountFromFile("./keys/", "your secure code")
+	if err != nil {
+		return nil, fmt.Errorf("create account error: %v\n", err)
+	}
+	// print the account, mnemonics
+	fmt.Println(acc.Address)
+
+	return acc, nil
 }
 
 func getBalance(mnemonic string) {


### PR DESCRIPTION
Modify the default configuration of `sdk.yaml` to the XuperOS endpoint and addresses.

```
# endorseService Info
# XuperOS  endorser service endpoint
endorseServiceHost: "39.156.69.83:37100"
# Endorser addresses and fee
complianceCheck:
  complianceCheckEndorseServiceFee: 100
  complianceCheckEndorseServiceFeeAddr: aB2hpHnTBDxko3UoP2BpBZRujwhdcAFoT
  complianceCheckEndorseServiceAddr: jknGxa6eyum1JrATWvSJKW3thJ9GKHA9n

```