### PR TITLE
Change the path of config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -27,7 +27,7 @@ type CommConfig struct {
 	Crypto             string                `yaml:"crypto,omitempty"`
 }
 
-const confPath = "./conf"
+const confPath = "../conf"
 const confName = "sdk.yaml"
 
 const CRYPTO_XCHAIN = "xchain"


### PR DESCRIPTION
./conf --> ../conf，路径不一致导致执行过程中无法定位到配置文件，每次执行都会报 "Config yamlFile get error..." 错误。