### PR TITLE
PreExec tx return gasUsed and process slice parameters when invoke evm contract

### DIFF
--- a/xuper/request.go
+++ b/xuper/request.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
+	"regexp"
 
 	"github.com/xuperchain/xuper-sdk-go/v2/account"
 	"github.com/xuperchain/xuper-sdk-go/v2/common"
@@ -337,10 +338,20 @@ func convertToXuper3EvmArgs(args map[string]interface{}) (map[string][]byte, err
 
 func generateInvokeArgs(arg map[string]string, module string) (map[string][]byte, error) {
 	if module == EvmContractModule {
-		// todo
 		argsTmp := make(map[string]interface{}, len(arg))
 		for k, v := range arg {
-			argsTmp[k] = v
+			// 对evm合约请求中的切片参数进行处理
+			reg := regexp.MustCompile(`\[.*,?.*]`)
+			if reg.MatchString(v) {
+				sliceArg := make([]interface{}, 0)
+				err := json.Unmarshal([]byte(v), &sliceArg)
+				if err != nil {
+					return nil, err
+				}
+				argsTmp[k] = sliceArg
+			} else {
+				argsTmp[k] = v
+			}
 		}
 		return convertToXuper3EvmArgs(argsTmp)
 

--- a/xuper/xuperclient.go
+++ b/xuper/xuperclient.go
@@ -120,7 +120,7 @@ func (x *XClient) initConn() error {
 	if x.opt.useGrpcGZIP { // gzip enabled
 		grpcOpts = append(grpcOpts, grpc.WithDefaultCallOptions(grpc.UseCompressor(gzip.Name)))
 	}
-	maxRecvMshSize := 64<<20-1
+	maxRecvMshSize := 64<<20 - 1
 	if x.cfg.MaxRecvMsgSize != 0 {
 		maxRecvMshSize = x.cfg.MaxRecvMsgSize
 	}
@@ -467,6 +467,7 @@ func (x *XClient) PreExecTx(req *Request) (*Transaction, error) {
 
 	return &Transaction{
 		ContractResponse: cr,
+		GasUsed:          proposal.preResp.GetResponse().GetGasUsed(),
 	}, nil
 }
 


### PR DESCRIPTION
## Description

xuper/xuperclient.go: add field GasUsed when return the Transaction so that users can know how many gas they cost while pre-execute or post a transaction to the chain.

xuper/request.go: process slice parameters(they can be string slice, float64 slice or empty slice) when invoke evm contract.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Brief of your solution

Return gasUsed when post tx.
Process slice parameters when invoke evm contract.

## How Has This Been Tested?

There is a evm function declare like this:

``` solidity
function createUsers(
        address[] calldata users, // create multiple users
        uint256[] calldata ids, // each user's id
    ) external {}
```

The previous code will parse request parameter users `"[\"2462380BA1B39BB42AD9AECCAC7E91CB9D40AC27\",\"1A9BDAB96390EF0E4820519A95FCB96856202BB0\"]"` and ids `"[\"1\",\"2\"]"` to string not the slice then lead to failure, the latest code will parse it correctly.